### PR TITLE
Use nvidia-ml-py and psutil to replace original command line call

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,16 +49,14 @@ To install the latest version (master branch) via pip:
 pip install git+https://github.com/wookayin/gpustat.git@master
 ```
 
-Alternatively, you can just download an *unstable* version of [gpustat.py][script_gitio] (or any [stable version][script_stable]) into somewhere in `PATH`, e.g. `~/.local/bin/`
-(when you do not have root privilege, for example):
+If you don't have root privilege, you can try `pip install --user` as well.
+Please note that from v0.4, `gpustat.py` is no more a zero-dependency executable.
 
 ```
 sudo wget https://git.io/gpustat.py -O /usr/local/bin/gpustat && sudo chmod +x /usr/local/bin/gpustat
 ```
 
 [pypi_gpustat]: https://pypi.python.org/pypi/gpustat
-[script_gitio]: https://git.io/gpustat.py
-[script_stable]: https://raw.githubusercontent.com/wookayin/gpustat/v0.3.1/gpustat.py
 
 
 License

--- a/gpustat.py
+++ b/gpustat.py
@@ -8,7 +8,6 @@ the gpustat script :)
 """
 
 from __future__ import print_function
-from subprocess import check_output, CalledProcessError
 from datetime import datetime
 from collections import defaultdict
 from six.moves import cStringIO as StringIO
@@ -30,12 +29,6 @@ __version__ = '0.4.0.dev0'
 NOT_SUPPORTED = 'Not Supported'
 
 term = Terminal()
-
-def execute_process(command_shell):
-    stdout = check_output(command_shell, shell=True).strip()
-    if not isinstance(stdout, (str)):
-        stdout = stdout.decode()
-    return stdout
 
 
 class GPUStat(object):
@@ -114,6 +107,14 @@ class GPUStat(object):
         """
         v = self.entry['utilization.gpu']
         return int(v) if v is not None else None
+
+    @property
+    def processes(self):
+        """
+        Get the list of running processes on the GPU.
+        """
+        return list(self.entry['processes'])
+
 
     def print_to(self, fp,
                  with_colors=True,
@@ -368,8 +369,8 @@ def print_gpustat(json=False, debug=False, **args):
     '''
     try:
         gpu_stats = GPUStatCollection.new_query()
-    except CalledProcessError:
-        sys.stderr.write('Error on calling nvidia-smi. Use --debug flag for details\n')
+    except Exception:
+        sys.stderr.write('Error on querying NVIDIA devices. Use --debug flag for details\n')
         if debug:
             import traceback
             traceback.print_exc(file=sys.stderr)

--- a/gpustat.py
+++ b/gpustat.py
@@ -125,7 +125,7 @@ class GPUStat(object):
         # color settings
         colors = {}
         def _conditional(cond_fn, true_value, false_value,
-                         error_value=term.gray):
+                         error_value=term.bold_black):
             try:
                 if cond_fn(): return true_value
                 else: return false_value

--- a/gpustat.py
+++ b/gpustat.py
@@ -24,7 +24,7 @@ import os.path
 import pynvml as N
 from blessings import Terminal
 
-__version__ = '0.4.0.dev'
+__version__ = '0.4.0.dev0'
 
 
 NOT_SUPPORTED = 'Not Supported'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+nvidia-ml-py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 nvidia-ml-py
 psutil
+blessings

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+six
 nvidia-ml-py
 psutil
 blessings

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 six
-nvidia-ml-py
+nvidia-ml-py; python_version <= '2.7'
+nvidia-ml-py3; python_version >= '3.0'
 psutil
-blessings
+blessings>=1.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 nvidia-ml-py
+psutil

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,20 @@ def read_readme():
     with open('README.md') as f:
         return f.read()
 
+install_requires = [
+    'six',
+    'nvidia-ml-py>=7.352.0' if IS_PY_2 else \
+        'nvidia-ml-py3>=7.352.0',
+    'psutil',
+    'blessings>=1.6',
+]
+
+tests_requires = [
+    'mock>=2.0.0',
+    'nose',
+    'nose-cover3'
+]
+
 setup(
     name='gpustat',
     version=gpustat.__version__,
@@ -30,15 +44,10 @@ setup(
     ],
     #packages=['gpustat'],
     py_modules=['gpustat'],
-    install_requires=[
-        'six',
-        'nvidia-ml-py>=7.352.0' if IS_PY_2 else \
-            'nvidia-ml-py3>=7.352.0',
-        'psutil',
-        'blessings>=1.6',
-    ],
+    install_requires=install_requires,
+    extras_require={'test': tests_requires},
+    tests_require=tests_requires,
     test_suite='nose.collector',
-    tests_require=['nose', 'nose-cover3'],
     entry_points={
         'console_scripts': ['gpustat=gpustat:main'],
     },

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,8 @@
 from setuptools import setup
+import sys
+
+IS_PY_2 = (sys.version_info[0] <= 2)
+
 import gpustat
 
 def read_readme():
@@ -27,6 +31,11 @@ setup(
     #packages=['gpustat'],
     py_modules=['gpustat'],
     install_requires=[
+        'six',
+        'nvidia-ml-py>=7.352.0' if IS_PY_2 else \
+            'nvidia-ml-py3>=7.352.0',
+        'psutil',
+        'blessings>=1.6',
     ],
     test_suite='nose.collector',
     tests_require=['nose', 'nose-cover3'],

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,25 @@
 from setuptools import setup
 import sys
+import os
+import re
 
 IS_PY_2 = (sys.version_info[0] <= 2)
 
-import gpustat
 
 def read_readme():
     with open('README.md') as f:
         return f.read()
+
+def read_version():
+    # importing gpustat causes an ImportError :-)
+    __PATH__ = os.path.abspath(os.path.dirname(__file__))
+    with open(os.path.join(__PATH__, 'gpustat.py')) as f:
+        version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                                  f.read(), re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find __version__ string")
+
 
 install_requires = [
     'six',
@@ -25,7 +37,7 @@ tests_requires = [
 
 setup(
     name='gpustat',
-    version=gpustat.__version__,
+    version=read_version(),
     license='MIT',
     description='An utility to monitor NVIDIA GPU status (wrapper of nvidia-smi)',
     long_description=read_readme(),

--- a/test_gpustat.py
+++ b/test_gpustat.py
@@ -7,11 +7,7 @@ from __future__ import print_function
 import unittest
 import gpustat
 from collections import namedtuple
-
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from io import StringIO
+from six.moves import cStringIO as StringIO
 
 try:
     import unittest.mock as mock
@@ -29,7 +25,6 @@ def _configure_mock(N, Process):
     Define mock behaviour for N: the pynvml module, and psutil.Process,
     which should be MagicMock objects from unittest.mock.
     """
-    print(N)
 
     # Restore some non-mock objects (such as exceptions)
     for attr in dir(pynvml):

--- a/test_gpustat.py
+++ b/test_gpustat.py
@@ -6,54 +6,130 @@ from __future__ import print_function
 
 import unittest
 import gpustat
+from collections import namedtuple
 
 try:
     from cStringIO import StringIO
 except ImportError:
     from io import StringIO
 
-# mock output for test
-def _mock_check_output(cmd, shell=True):
-    if cmd.startswith('nvidia-smi --query-compute-apps'):
-        return u'''\
-GPU-10fb0fbd-2696-43f3-467f-d280d906a107, 48448, 4000
-GPU-10fb0fbd-2696-43f3-467f-d280d906a107, 153223, 4000
-GPU-d1df4664-bb44-189c-7ad0-ab86c8cb30e2, 192453, 3000
-GPU-d1df4664-bb44-189c-7ad0-ab86c8cb30e2, 194826, 6000
-GPU-50205d95-57b6-f541-2bcb-86c09afed564, 38310, 4245
-GPU-50205d95-57b6-f541-2bcb-86c09afed564, [Not Supported], [Not Supported]
-'''
-    elif cmd.startswith('nvidia-smi --query-gpu'):
-        return u'''\
-0, GPU-10fb0fbd-2696-43f3-467f-d280d906a107, GeForce GTX TITAN X, 80, 76, 8000, 12287
-1, GPU-d1df4664-bb44-189c-7ad0-ab86c8cb30e2, GeForce GTX TITAN X, 36, 0, 9000, 12287
-2, GPU-50205d95-57b6-f541-2bcb-86c09afed564, GeForce GTX TITAN X, 71, [Not Supported], 8520, 12287
-'''
-    elif cmd.startswith('ps -o pid,user:16,comm -p'):
-        return u'''\
-   PID USER  COMMAND
- 48448 user1 python
-154213 user1 caffe
- 38310 user3 python
-153223 user2 python
-194826 user3 caffe
-192453 user1 torch
-'''
-    else:
-        raise ValueError(cmd)
+try:
+    import unittest.mock as mock
+except:
+    import mock
 
-# mocking (override subprocess.check_output)
-gpustat.check_output = _mock_check_output
+MagicMock = mock.MagicMock
 
+import psutil
+import pynvml
+
+
+def _configure_mock(N, Process):
+    """
+    Define mock behaviour for N: the pynvml module, and psutil.Process,
+    which should be MagicMock objects from unittest.mock.
+    """
+    print(N)
+
+    # Restore some non-mock objects (such as exceptions)
+    for attr in dir(pynvml):
+        if attr.startswith('NVML'):
+            setattr(N, attr, getattr(pynvml, attr))
+    assert issubclass(N.NVMLError, BaseException)
+
+    # without following patch, unhashable NVMLError distrubs unit test
+    N.NVMLError.__hash__ = lambda _: 0
+
+
+    # mock-patch every nvml**** functions used in gpustat.
+    N.nvmlInit = MagicMock()
+    N.nvmlShutdown = MagicMock()
+    N.nvmlDeviceGetCount.return_value = 3
+
+    mock_handles = ['mock-handle-%d' % i for i in range(3)]
+    def _raise_ex(fn):
+        """ Decorator to let exceptions returned from the callable re-throwed. """
+        def _decorated(*args, **kwargs):
+            v = fn(*args, **kwargs)
+            if isinstance(v, Exception): raise v
+            return v
+        return _decorated
+
+    N.nvmlDeviceGetHandleByIndex.side_effect=(lambda index: mock_handles[index])
+    N.nvmlDeviceGetName.side_effect = _raise_ex(lambda handle: {
+        mock_handles[0]: b'GeForce GTX TITAN 0',
+        mock_handles[1]: b'GeForce GTX TITAN 1',
+        mock_handles[2]: b'GeForce GTX TITAN 2',
+    }.get(handle, RuntimeError))
+    N.nvmlDeviceGetUUID.side_effect = _raise_ex(lambda handle: {
+        mock_handles[0]: b'GPU-10fb0fbd-2696-43f3-467f-d280d906a107',
+        mock_handles[1]: b'GPU-d1df4664-bb44-189c-7ad0-ab86c8cb30e2',
+        mock_handles[2]: b'GPU-50205d95-57b6-f541-2bcb-86c09afed564',
+    }.get(handle, RuntimeError))
+
+    N.nvmlDeviceGetTemperature = _raise_ex(lambda handle, _: {
+        mock_handles[0]: 80,
+        mock_handles[1]: 36,
+        mock_handles[2]: 71,
+    }.get(handle, RuntimeError))
+
+    mock_memory_t = namedtuple("Memory_t", ['total', 'used'])
+    N.nvmlDeviceGetMemoryInfo.side_effect = _raise_ex(lambda handle: {
+        mock_handles[0]: mock_memory_t(total=12883853312, used=8000*MB),
+        mock_handles[1]: mock_memory_t(total=12781551616, used=9000*MB),
+        mock_handles[2]: mock_memory_t(total=12781551616, used=0),
+    }.get(handle, RuntimeError))
+
+    mock_utilization_t = namedtuple("Utilization_t", ['gpu', 'memory'])
+    N.nvmlDeviceGetUtilizationRates.side_effect = _raise_ex(lambda handle: {
+        mock_handles[0]: mock_utilization_t(gpu=76, memory=0),
+        mock_handles[1]: mock_utilization_t(gpu=0, memory=0),
+        mock_handles[2]: N.NVMLError_NotSupported(),  # Not Supported
+    }.get(handle, RuntimeError))
+
+    # running process information: a bit annoying...
+    mock_process_t = namedtuple("Process_t", ['pid', 'usedGpuMemory'])
+    N.nvmlDeviceGetComputeRunningProcesses.side_effect = _raise_ex(lambda handle: {
+        mock_handles[0]: [mock_process_t(48448, 4000*MB), mock_process_t(153223, 4000*MB)],
+        mock_handles[1]: [mock_process_t(192453, 3000*MB), mock_process_t(194826, 6000*MB)],
+        mock_handles[2]: N.NVMLError_NotSupported(),  # Not Supported
+    }.get(handle, RuntimeError))
+
+    mock_pid_map = {   # mock information for psutil...
+        48448:  ('user1', 'python'),
+        154213: ('user1', 'caffe'),
+        38310:  ('user3', 'python'),
+        153223: ('user2', 'python'),
+        194826: ('user3', 'caffe'),
+        192453: ('user1', 'torch'),
+    }
+
+    def _MockedProcess(pid):
+        username, cmdline = mock_pid_map[pid]
+        p = MagicMock()  # mocked process
+        p.username.return_value = username
+        p.cmdline.return_value = [cmdline]
+        return p
+    Process.side_effect = _MockedProcess
+
+
+
+MB = 1024 * 1024
 
 def remove_ansi_codes(s):
     import re
-    ansi_escape = re.compile(r'\x1b[^m]*m')
-    return ansi_escape.sub('', s)
+    s = re.compile(r'\x1b[^m]*m').sub('', s)
+    s = re.compile(r'\x0f').sub('', s)
+    return s
+
 
 class TestGPUStat(unittest.TestCase):
 
-    def test_new_query_mocked(self):
+    @mock.patch('psutil.Process')
+    @mock.patch('gpustat.N')
+    def test_new_query_mocked(self, N, Process):
+        _configure_mock(N, Process)
+
         gpustats = gpustat.new_query()
         fp = StringIO()
         gpustats.print_formatted(fp=fp, no_color=False, show_user=True, show_cmd=True, show_pid=True)
@@ -62,16 +138,23 @@ class TestGPUStat(unittest.TestCase):
         print(result)
 
         unescaped = remove_ansi_codes(result)
-        self.assertEqual(unescaped,
-"""\
-[0] GeForce GTX TITAN X | 80'C,  76 % |  8000 / 12287 MB | user1:python/48448(4000M) user2:python/153223(4000M)
-[1] GeForce GTX TITAN X | 36'C,   0 % |  9000 / 12287 MB | user1:torch/192453(3000M) user3:caffe/194826(6000M)
-[2] GeForce GTX TITAN X | 71'C,  ?? % |  8520 / 12287 MB | user3:python/38310(4245M) --:--/--(?M)
-""")
-        #"""
+        # remove first line (header)
+        unescaped = '\n'.join(unescaped.split('\n')[1:])
 
-    def test_attributes_and_items(self):
-        g = gpustat.new_query()[2]  # includes N/A
+        expected = """\
+[0] GeForce GTX TITAN 0 | 80'C,  76 % |  8000 / 12287 MB | user1:python/48448(4000M) user2:python/153223(4000M)
+[1] GeForce GTX TITAN 1 | 36'C,   0 % |  9000 / 12189 MB | user1:torch/192453(3000M) user3:caffe/194826(6000M)
+[2] GeForce GTX TITAN 2 | 71'C,  ?? % |     0 / 12189 MB | (Not Supported)
+"""
+        self.maxDiff = 4096
+        self.assertEqual(unescaped, expected)
+
+    @mock.patch('psutil.Process')
+    @mock.patch('gpustat.N')
+    def test_attributes_and_items(self, N, Process):
+        _configure_mock(N, Process)
+
+        g = gpustat.new_query()[1]  # includes N/A
         print("(keys) : %s" % str(g.keys()))
         print(g)
 


### PR DESCRIPTION
This is a support and follow-up for #17 by @Stonesjtu, in which all `nvidia-smi` and `ps` command line calls are replaced by `nvidia-ml-py` and `psutil`, respectively. On top of #17, I have added unit tests and fixed several bugs (or different behavior) introduced in the PR.

### Changes

- Replace `nvidia-smi` call by `nvidia-ml-py` and `psutil`.
  - As a result, querying nvidia devices gets much faster (even without `nvidia-smi daemon`); moreover, we can obtain more detailed information on GPUs and processes.
- Numerical information such as memory usage now will be given in bytes, not in mega-bytes (Breaking change).