### PR TITLE
Support python3 in --json option

### DIFF
--- a/gpustat.py
+++ b/gpustat.py
@@ -21,8 +21,6 @@ import platform
 import json
 import six
 
-__version__ = '0.4.0.dev'
-
 
 class ANSIColors:
     RESET   = '\033[0m'

--- a/gpustat.py
+++ b/gpustat.py
@@ -19,6 +19,7 @@ import sys
 import locale
 import platform
 import json
+import six
 
 __version__ = '0.4.0.dev'
 
@@ -198,7 +199,7 @@ class GPUStat(object):
 
     def jsonify(self):
         o = dict(self.entry)
-        o['processes'] = [{k: v for (k, v) in p.iteritems() if k != 'gpu_uuid'}
+        o['processes'] = [{k: v for (k, v) in six.iteritems(p) if k != 'gpu_uuid'}
                           for p in self.processes]
         return o
 

--- a/gpustat.py
+++ b/gpustat.py
@@ -19,7 +19,6 @@ import sys
 import locale
 import platform
 import json
-import six
 
 __version__ = '0.4.0.dev'
 
@@ -198,6 +197,7 @@ class GPUStat(object):
         return self.entry['uuid']
 
     def jsonify(self):
+        import six
         o = dict(self.entry)
         o['processes'] = [{k: v for (k, v) in six.iteritems(p) if k != 'gpu_uuid'}
                           for p in self.processes]

--- a/gpustat.py
+++ b/gpustat.py
@@ -21,6 +21,8 @@ import platform
 import json
 import six
 
+__version__ = '0.4.0.dev'
+
 
 class ANSIColors:
     RESET   = '\033[0m'

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,7 @@ setup(
     ],
     #packages=['gpustat'],
     py_modules=['gpustat'],
-    install_requires=[
-    ],
+    install_requires=['six'],
     test_suite='nose.collector',
     tests_require=['nose', 'nose-cover3'],
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup
+import gpustat
 
 def read_readme():
     with open('README.md') as f:
@@ -6,7 +7,7 @@ def read_readme():
 
 setup(
     name='gpustat',
-    version='0.4.0.dev',
+    version=gpustat.__version__,
     license='MIT',
     description='An utility to monitor NVIDIA GPU status (wrapper of nvidia-smi)',
     long_description=read_readme(),

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from setuptools import setup
-import gpustat
 
 def read_readme():
     with open('README.md') as f:
@@ -7,7 +6,7 @@ def read_readme():
 
 setup(
     name='gpustat',
-    version=gpustat.__version__,
+    version='0.4.0.dev',
     license='MIT',
     description='An utility to monitor NVIDIA GPU status (wrapper of nvidia-smi)',
     long_description=read_readme(),


### PR DESCRIPTION
`--json` option does not work when using python3, as `iteritems()` is not available in python3.

Thus, I add `six` module so that both python2 and python3 can use `--json` option.

Also, I had to directly write version information in `setup.py` as importing `gpustat.py` in `setup.py` causes an installation error. (`setup.py` tries and fails to import yet-not-installed `six`)

