### PR TITLE
Fix bug that NVML returns non-existing pids

### DIFF
--- a/gpustat.py
+++ b/gpustat.py
@@ -257,8 +257,13 @@ class GPUStatCollection(object):
                 for nv_process in nv_processes:
                     #TODO: could be more information such as system memory usage,
                     # CPU percentage, create time etc.
-                    process = get_process_info(nv_process.pid)
-                    processes.append(process)
+                    try:
+                        process = get_process_info(nv_process.pid)
+                        processes.append(process)
+                    except psutil.NoSuchProcess:
+                        #TODO: add some reminder for NVML broken context
+                        # e.g. nvidia-smi reset  or  reboot the system
+                        pass
             except N.NVMLError:
                 processes = None  # Not supported
 


### PR DESCRIPTION
Handle the exception `NoSuchProcess` raised by `psutil`.

Fix #16 #18. 