### PR TITLE
Print degrees with correct symbol

### DIFF
--- a/gpustat/core.py
+++ b/gpustat/core.py
@@ -189,7 +189,7 @@ class GPUStat(object):
         # temperature and utilization
         reps = "%(C1)s[{entry[index]}]%(C0)s " \
             "%(CName)s{entry[name]:{gpuname_width}}%(C0)s |" \
-            "%(CTemp)s{entry[temperature.gpu]:>3}'C%(C0)s, " \
+            "%(CTemp)s{entry[temperature.gpu]:>3}°C%(C0)s, " \
             "%(CUtil)s{entry[utilization.gpu]:>3} %%%(C0)s"
 
         if show_power:

--- a/gpustat/core.py
+++ b/gpustat/core.py
@@ -11,6 +11,7 @@ Implementation of gpustat
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import json
 import locale
@@ -188,7 +189,7 @@ class GPUStat(object):
         # build one-line display information
         # we want power use optional, but if deserves being grouped with
         # temperature and utilization
-        reps = "%(C1)s[{entry[index]}]%(C0)s " \
+        reps = u"%(C1)s[{entry[index]}]%(C0)s " \
             "%(CName)s{entry[name]:{gpuname_width}}%(C0)s |" \
             "%(CTemp)s{entry[temperature.gpu]:>3}°C%(C0)s, " \
             "%(CUtil)s{entry[utilization.gpu]:>3} %%%(C0)s"

--- a/gpustat/core.py
+++ b/gpustat/core.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 """
 Implementation of gpustat

--- a/gpustat/test_gpustat.py
+++ b/gpustat/test_gpustat.py
@@ -147,15 +147,15 @@ def _configure_mock(N, Process,
 
 
 MOCK_EXPECTED_OUTPUT_DEFAULT = """\
-[0] GeForce GTX TITAN 0 | 80'C,  76 % |  8000 / 12287 MB | user1(4000M) user2(4000M)
-[1] GeForce GTX TITAN 1 | 36'C,   0 % |  9000 / 12189 MB | user1(3000M) user3(6000M)
-[2] GeForce GTX TITAN 2 | 71'C,  ?? % |     0 / 12189 MB | (Not Supported)
+[0] GeForce GTX TITAN 0 | 80°C,  76 % |  8000 / 12287 MB | user1(4000M) user2(4000M)
+[1] GeForce GTX TITAN 1 | 36°C,   0 % |  9000 / 12189 MB | user1(3000M) user3(6000M)
+[2] GeForce GTX TITAN 2 | 71°C,  ?? % |     0 / 12189 MB | (Not Supported)
 """  # noqa: E501
 
 MOCK_EXPECTED_OUTPUT_FULL = """\
-[0] GeForce GTX TITAN 0 | 80'C,  76 %,  125 / 250 W |  8000 / 12287 MB | user1:python/48448(4000M) user2:python/153223(4000M)
-[1] GeForce GTX TITAN 1 | 36'C,   0 %,   ?? / 250 W |  9000 / 12189 MB | user1:torch/192453(3000M) user3:caffe/194826(6000M)
-[2] GeForce GTX TITAN 2 | 71'C,  ?? %,  250 /  ?? W |     0 / 12189 MB | (Not Supported)
+[0] GeForce GTX TITAN 0 | 80°C,  76 %,  125 / 250 W |  8000 / 12287 MB | user1:python/48448(4000M) user2:python/153223(4000M)
+[1] GeForce GTX TITAN 1 | 36°C,   0 %,   ?? / 250 W |  9000 / 12189 MB | user1:torch/192453(3000M) user3:caffe/194826(6000M)
+[2] GeForce GTX TITAN 2 | 71°C,  ?? %,  250 /  ?? W |     0 / 12189 MB | (Not Supported)
 """  # noqa: E501
 
 

--- a/gpustat/test_gpustat.py
+++ b/gpustat/test_gpustat.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """
 Unit or integration tests for gpustat
 """


### PR DESCRIPTION
Use degree symbol instead of apostrophe when printing temperature units.

Example:
40°C instead of 40'C