### PR TITLE
Add full process info.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Options:
 * `--no-color`         : Suppress colored output
 * `-u`, `--show-user`  : Display username of the process owner
 * `-c`, `--show-cmd`   : Display the process name
+* `-f`, `--show-full-cmd`   : Display full command and cpu stats of running process
 * `-p`, `--show-pid`   : Display PID of the process
 * `-F`, `--show-fan`   : Display GPU fan speed
 * `-P`, `--show-power` : Display GPU power usage and/or limit (`draw` or `draw,limit`)

--- a/gpustat/__main__.py
+++ b/gpustat/__main__.py
@@ -75,6 +75,10 @@ def main(*argv):
 
     parser.add_argument('-c', '--show-cmd', action='store_true',
                         help='Display cmd name of running process')
+    parser.add_argument(
+        '-f', '--show-full-cmd', action='store_true',
+        help='Display full command and cpu stats of running process'
+    )
     parser.add_argument('-u', '--show-user', action='store_true',
                         help='Display username of running process')
     parser.add_argument('-p', '--show-pid', action='store_true',

--- a/gpustat/core.py
+++ b/gpustat/core.py
@@ -417,7 +417,9 @@ class GPUStatCollection(object):
                         pass
                 time.sleep(0.1)
                 for process in processes:
-                    process['cpu_percent'] = GPUStatCollection.global_processes[process['pid']].cpu_percent()
+                    pid = process['pid']
+                    cache_process = GPUStatCollection.global_processes[pid]
+                    process['cpu_percent'] = cache_process.cpu_percent()
 
             index = N.nvmlDeviceGetIndex(handle)
             gpu_info = {


### PR DESCRIPTION
Fixes #50 

I added `-f`, `--show-full-cmd` that show the full process info as discussed in #50.

Right now it shows the percent of CPU usage and the percent of system memory in use, but that can be changed.

Let me know what you think.

Example:
```
server1  Wed Jun 26 15:24:33 2019  418.67
[0] Tesla V100-SXM2-16GB | 34'C,  23 % |  1097 / 16130 MB | user1(1087M)
 └─ 72041 ( 80%,  0.24%): python /mnt/home/user1/git/horovod/examples/keras_mnist.py
[1] Tesla V100-SXM2-16GB | 36'C,  23 % |  1097 / 16130 MB | user1(1087M)
 └─ 72042 ( 80%,  0.24%): python /mnt/home/user1/git/horovod/examples/keras_mnist.py
[2] Tesla V100-SXM2-16GB | 35'C, 100 % |  2130 / 16130 MB | user2(777M) user1(1343M)
 ├─ 95638 (100%,  0.16%): /mnt/home/user2/anaconda3/envs/env/bin/python test_c10d.py
 └─ 72043 (100%,  0.24%): python /mnt/home/user1/git/horovod/examples/keras_mnist.py
[3] Tesla V100-SXM2-16GB | 34'C,  22 % |  1097 / 16130 MB | user1(1087M)
 └─ 72044 ( 40%,  0.24%): python /mnt/home/user1/git/horovod/examples/keras_mnist.py
```