### PR TITLE
Stop supporting Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 matrix:
   include:
-    - python: "2.7"
     - python: "3.4"
     - python: "3.5"
     - python: "3.6"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 six>=1.7
-nvidia-ml-py; python_version <= '2.7'
-nvidia-ml-py3; python_version >= '3.0'
+nvidia-ml-py3
 psutil
 blessings>=1.6

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,6 @@ import sys
 import os
 import re
 
-IS_PY_2 = (sys.version_info[0] <= 2)
-
-
 def read_readme():
     with open('README.md') as f:
         return f.read()
@@ -24,7 +21,7 @@ def read_version():
 
 install_requires = [
     'six>=1.7',
-    'nvidia-ml-py>=7.352.0' if IS_PY_2 else 'nvidia-ml-py3>=7.352.0',
+    'nvidia-ml-py3>=7.352.0',
     'psutil',
     'blessings>=1.6',
 ]
@@ -50,7 +47,6 @@ setup(
         'Development Status :: 3 - Alpha',
         'License :: OSI Approved :: MIT License',
         'Operating System :: POSIX :: Linux',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Topic :: System :: Monitoring',
     ],
@@ -64,4 +60,5 @@ setup(
     },
     include_package_data=True,
     zip_safe=False,
+    python_requires='>=3.4',
 )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
-import sys
 import os
 import re
+
 
 def read_readme():
     with open('README.md') as f:


### PR DESCRIPTION
Fixes #66.

Python 2 is being retired. This change should remove support for it going forward, but if a user still wants to use Python 2 they would just get the older version.