### PR TITLE
Add windows support with blessed

### DIFF
--- a/gpustat/cli.py
+++ b/gpustat/cli.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 import sys
 import time
 
-from blessings import Terminal
+from blessed import Terminal
 
 from gpustat import __version__
 from .core import GPUStatCollection
@@ -60,9 +60,11 @@ def main(*argv):
         argv = list(sys.argv)
 
     # attach SIGPIPE handler to properly handle broken pipe
-    import signal
-    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
-
+    try: # sigpipe not available under windows. just ignore in this case
+        import signal
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+    except Exception as e:
+        pass
     # arguments to gpustat
     import argparse
     parser = argparse.ArgumentParser()

--- a/gpustat/core.py
+++ b/gpustat/core.py
@@ -24,7 +24,7 @@ from datetime import datetime
 from six.moves import cStringIO as StringIO
 import psutil
 import pynvml as N
-from blessings import Terminal
+from blessed import Terminal
 
 import gpustat.util as util
 
@@ -345,7 +345,10 @@ class GPUStatCollection(object):
                     process['command'] = os.path.basename(_cmdline[0])
                     process['full_command'] = _cmdline
                 # Bytes to MBytes
-                process['gpu_memory_usage'] = nv_process.usedGpuMemory // MB
+                # if drivers are not TTC this will be None. 
+                usedmem = nv_process.usedGpuMemory // MB if \
+                          nv_process.usedGpuMemory else None
+                process['gpu_memory_usage'] = usedmem
                 process['cpu_percent'] = ps_process.cpu_percent()
                 process['cpu_memory_usage'] = \
                     round((ps_process.memory_percent() / 100.0) *
@@ -503,8 +506,15 @@ class GPUStatCollection(object):
 
         # header
         if show_header:
-            time_format = locale.nl_langinfo(locale.D_T_FMT)
-
+            # no localization is available that easily
+            # however,everybody should be able understand the
+            # standard datetime string format %Y-%m-%d %H:%M:%S
+            if 'windows' in platform.platform().lower():
+                # same as str(timestr) but without ms
+                timestr = self.query_time.strftime('%Y-%m-%d %H:%M:%S')
+            else:
+                time_format = locale.nl_langinfo(locale.D_T_FMT)
+                timestr = self.query_time.strftime(time_format)
             header_template = '{t.bold_white}{hostname:{width}}{t.normal}  '
             header_template += '{timestr}  '
             header_template += '{t.bold_black}{driver_version}{t.normal}'
@@ -512,7 +522,7 @@ class GPUStatCollection(object):
             header_msg = header_template.format(
                     hostname=self.hostname,
                     width=gpuname_width + 3,  # len("[?]")
-                    timestr=self.query_time.strftime(time_format),
+                    timestr=timestr,
                     driver_version=self.driver_version,
                     t=t_color,
                 )

--- a/gpustat/core.py
+++ b/gpustat/core.py
@@ -493,7 +493,7 @@ class GPUStatCollection(object):
             raise ValueError("--color and --no_color can't"
                              " be used at the same time")
 
-        if force_color and not self.is_windows():
+        if force_color:
             t_color = Terminal(kind='linux', force_styling=True)
 
             # workaround of issue #32 (watch doesn't recognize sgr0 characters)

--- a/gpustat/core.py
+++ b/gpustat/core.py
@@ -494,7 +494,8 @@ class GPUStatCollection(object):
             t_color = Terminal(kind='linux', force_styling=True)
 
             # workaround of issue #32 (watch doesn't recognize sgr0 characters)
-            t_color.normal = u'\x1b[0;10m'
+            try: t_color.normal = u'\x1b[0;10m'
+            except: pass
         elif no_color:
             t_color = Terminal(force_styling=None)
         else:

--- a/gpustat/core.py
+++ b/gpustat/core.py
@@ -476,6 +476,9 @@ class GPUStatCollection(object):
         s += '\n'.join('  ' + str(g) for g in self.gpus)
         s += '\n])'
         return s
+    
+    def is_windows(self):
+        return 'windows' in platform.platform().lower()
 
     # --- Printing Functions ---
 
@@ -490,7 +493,7 @@ class GPUStatCollection(object):
             raise ValueError("--color and --no_color can't"
                              " be used at the same time")
 
-        if force_color:
+        if force_color and not self.is_windows():
             t_color = Terminal(kind='linux', force_styling=True)
 
             # workaround of issue #32 (watch doesn't recognize sgr0 characters)
@@ -510,7 +513,7 @@ class GPUStatCollection(object):
             # no localization is available that easily
             # however,everybody should be able understand the
             # standard datetime string format %Y-%m-%d %H:%M:%S
-            if 'windows' in platform.platform().lower():
+            if self.is_windows():
                 # same as str(timestr) but without ms
                 timestr = self.query_time.strftime('%Y-%m-%d %H:%M:%S')
             else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 six>=1.7
 nvidia-ml-py3
 psutil
-blessings>=1.6
+blessed>=1.16.1

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ install_requires = [
     'six>=1.7',
     'nvidia-ml-py3>=7.352.0',
     'psutil',
-    'blessings>=1.6',
+    'blessed>=1.16.1',
 ]
 
 tests_requires = [


### PR DESCRIPTION
I've re-added support for Windows and fixed the broken imports/code

Main changes:

- switched from `blessing` to `blessed`. Essentially the same library, yet also works on Windows
- skip loading of `signal.SIGPIPE` on Windows (not available). Don't know what that line's adding anyway.
- current time is just printed as a default formatter on Windows, as there's no easy way to get a `locale` formatting string
- If memory usage is `None`, report `None`


Some remarks: On Windows (and partially on Linux), newer NVIDIA drivers can only report the memory usage of individual processes if the card is in TCC (dedicated) mode, that means no monitor is attached to them.

It might be handy to report this in the README