### PR TITLE
Add support for enc/dec gpu utilization (#79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Options:
 * `-f`, `--show-full-cmd`   : Display full command and cpu stats of running process
 * `-p`, `--show-pid`   : Display PID of the process
 * `-F`, `--show-fan`   : Display GPU fan speed
+* `-e`, `--show-codec` : Display encoder and/or decoder utilization
 * `-P`, `--show-power` : Display GPU power usage and/or limit (`draw` or `draw,limit`)
 * `-a`, `--show-all`   : Display all gpu properties above
 * `--watch`, `-i`, `--interval`   : Run in watch mode (equivalent to `watch gpustat`) if given. Denotes interval between updates. ([#41][gh-issue-41])

--- a/gpustat/cli.py
+++ b/gpustat/cli.py
@@ -93,15 +93,18 @@ def main(*argv):
                         help='Display PID of running process')
     parser.add_argument('-F', '--show-fan-speed', '--show-fan',
                         action='store_true', help='Display GPU fan speed')
-    parser.add_argument('--json', action='store_true', default=False,
-                        help='Print all the information in JSON format')
-    parser.add_argument('-v', '--version', action='version',
-                        version=('gpustat %s' % __version__))
+    parser.add_argument(
+        '-e', '--show-codec', nargs='?', const='enc,dec', default='',
+        choices=['enc', 'dec', 'enc,dec'],
+        help='Show encoder/decoder utilization'
+    )
     parser.add_argument(
         '-P', '--show-power', nargs='?', const='draw,limit',
         choices=['', 'draw', 'limit', 'draw,limit', 'limit,draw'],
         help='Show GPU power usage or draw (and/or limit)'
     )
+    parser.add_argument('--json', action='store_true', default=False,
+                        help='Print all the information in JSON format')
     parser.add_argument(
         '-i', '--interval', '--watch', nargs='?', type=float, default=0,
         help='Use watch mode if given; seconds to wait between updates'
@@ -118,12 +121,15 @@ def main(*argv):
         '--debug', action='store_true', default=False,
         help='Allow to print additional informations for debugging.'
     )
+    parser.add_argument('-v', '--version', action='version',
+                        version=('gpustat %s' % __version__))
     args = parser.parse_args(argv[1:])
     if args.show_all:
         args.show_cmd = True
         args.show_user = True
         args.show_pid = True
         args.show_fan_speed = True
+        args.show_codec = 'enc,dec'
         args.show_power = 'draw,limit'
     del args.show_all
 

--- a/gpustat/core.py
+++ b/gpustat/core.py
@@ -133,6 +133,24 @@ class GPUStat(object):
         return int(v) if v is not None else None
 
     @property
+    def utilization_enc(self):
+        """
+        Returns the GPU encoder utilization (in percentile),
+        or None if the information is not available.
+        """
+        v = self.entry['utilization.enc']
+        return int(v) if v is not None else None
+
+    @property
+    def utilization_dec(self):
+        """
+        Returns the GPU decoder utilization (in percentile),
+        or None if the information is not available.
+        """
+        v = self.entry['utilization.dec']
+        return int(v) if v is not None else None
+
+    @property
     def power_draw(self):
         """
         Returns the GPU power usage in Watts,
@@ -387,6 +405,16 @@ class GPUStatCollection(object):
                 utilization = None  # Not supported
 
             try:
+                utilization_enc = N.nvmlDeviceGetEncoderUtilization(handle)
+            except N.NVMLError:
+                utilization_enc = None  # Not supported
+
+            try:
+                utilization_dec = N.nvmlDeviceGetDecoderUtilization(handle)
+            except N.NVMLError:
+                utilization_dec = None  # Not supported
+
+            try:
                 power = N.nvmlDeviceGetPowerUsage(handle)
             except N.NVMLError:
                 power = None
@@ -437,6 +465,10 @@ class GPUStatCollection(object):
                 'temperature.gpu': temperature,
                 'fan.speed': fan_speed,
                 'utilization.gpu': utilization.gpu if utilization else None,
+                'utilization.enc':
+                    utilization_enc[0] if utilization_enc else None,
+                'utilization.dec':
+                    utilization_dec[0] if utilization_dec else None,
                 'power.draw': power // 1000 if power is not None else None,
                 'enforced.power.limit': power_limit // 1000
                 if power_limit is not None else None,

--- a/gpustat/test_gpustat.py
+++ b/gpustat/test_gpustat.py
@@ -114,6 +114,18 @@ def _configure_mock(N, Process, virtual_memory,
         mock_handles[2]: N.NVMLError_NotSupported(),  # Not Supported
     }.get(handle, RuntimeError))
 
+    N.nvmlDeviceGetEncoderUtilization.side_effect = _raise_ex(lambda handle: {
+        mock_handles[0]: [88, 167000],  # [value, sample_rate]
+        mock_handles[1]: [0, 167000],  # [value, sample_rate]
+        mock_handles[2]: N.NVMLError_NotSupported(),  # Not Supported
+    }.get(handle, RuntimeError))
+
+    N.nvmlDeviceGetDecoderUtilization.side_effect = _raise_ex(lambda handle: {
+        mock_handles[0]: [67, 167000],  # [value, sample_rate]
+        mock_handles[1]: [0, 167000],  # [value, sample_rate]
+        mock_handles[2]: N.NVMLError_NotSupported(),  # Not Supported
+    }.get(handle, RuntimeError))
+
     # running process information: a bit annoying...
     mock_process_t = namedtuple("Process_t", ['pid', 'usedGpuMemory'])
 
@@ -273,6 +285,8 @@ class TestGPUStat(unittest.TestCase):
             g.memory_used, g.memory_total, g.memory_available))
         print("temperature : %d" % (g.temperature))
         print("utilization : %s" % (g.utilization))
+        print("utilization_enc : %s" % (g.utilization_enc))
+        print("utilization_dec : %s" % (g.utilization_dec))
 
     @unittest.skipIf(sys.version_info < (3, 4), "Only in Python 3.4+")
     @mock.patch('psutil.virtual_memory')

--- a/gpustat/test_gpustat.py
+++ b/gpustat/test_gpustat.py
@@ -179,19 +179,19 @@ MOCK_EXPECTED_OUTPUT_DEFAULT = os.linesep.join("""\
 """.splitlines())  # noqa: E501
 
 MOCK_EXPECTED_OUTPUT_FULL = os.linesep.join("""\
-[0] GeForce GTX TITAN 0 | 80°C,  16 %,  76 %,  125 / 250 W |  8000 / 12287 MB | user1:python/48448(4000M) user2:python/153223(4000M)
-[1] GeForce GTX TITAN 1 | 36°C,  53 %,   0 %,   ?? / 250 W |  9000 / 12189 MB | user1:torch/192453(3000M) user3:caffe/194826(6000M)
-[2] GeForce GTX TITAN 2 | 71°C, 100 %,  ?? %,  250 /  ?? W |     0 / 12189 MB | (Not Supported)
+[0] GeForce GTX TITAN 0 | 80°C,  16 %,  76 % (E:  88 %  D:  67 %),  125 / 250 W |  8000 / 12287 MB | user1:python/48448(4000M) user2:python/153223(4000M)
+[1] GeForce GTX TITAN 1 | 36°C,  53 %,   0 % (E:   0 %  D:   0 %),   ?? / 250 W |  9000 / 12189 MB | user1:torch/192453(3000M) user3:caffe/194826(6000M)
+[2] GeForce GTX TITAN 2 | 71°C, 100 %,  ?? % (E:  ?? %  D:  ?? %),  250 /  ?? W |     0 / 12189 MB | (Not Supported)
 """.splitlines())  # noqa: E501
 
 MOCK_EXPECTED_OUTPUT_FULL_PROCESS = os.linesep.join("""\
-[0] GeForce GTX TITAN 0 | 80°C,  16 %,  76 %,  125 / 250 W |  8000 / 12287 MB | user1:python/48448(4000M) user2:python/153223(4000M)
+[0] GeForce GTX TITAN 0 | 80°C,  16 %,  76 % (E:  88 %  D:  67 %),  125 / 250 W |  8000 / 12287 MB | user1:python/48448(4000M) user2:python/153223(4000M)
  ├─  48448 (  85%,  257MB): python
  └─ 153223 (  15%,     0B): python
-[1] GeForce GTX TITAN 1 | 36°C,  53 %,   0 %,   ?? / 250 W |  9000 / 12189 MB | user1:torch/192453(3000M) user3:caffe/194826(6000M)
+[1] GeForce GTX TITAN 1 | 36°C,  53 %,   0 % (E:   0 %  D:   0 %),   ?? / 250 W |  9000 / 12189 MB | user1:torch/192453(3000M) user3:caffe/194826(6000M)
  ├─ 192453 ( 123%,   59MB): torch
  └─ 194826 (   0%, 1025MB): caffe
-[2] GeForce GTX TITAN 2 | 71°C, 100 %,  ?? %,  250 /  ?? W |     0 / 12189 MB | (Not Supported)
+[2] GeForce GTX TITAN 2 | 71°C, 100 %,  ?? % (E:  ?? %  D:  ?? %),  250 /  ?? W |     0 / 12189 MB | (Not Supported)
 """.splitlines())  # noqa: E501
 
 
@@ -232,8 +232,8 @@ class TestGPUStat(unittest.TestCase):
         fp = StringIO()
         gpustats.print_formatted(
             fp=fp, no_color=False, show_user=True,
-            show_cmd=True, show_pid=True, show_power=True, show_fan_speed=True,
-            show_full_cmd=True
+            show_cmd=True, show_full_cmd=True, show_pid=True,
+            show_fan_speed=True, show_codec="enc,dec", show_power=True,
         )
 
         result = fp.getvalue()


### PR DESCRIPTION
This PR only adds encoder and decoder utilization to `--json` from the cmdline, or to the `GPUStat` object if `gpustat` is used as a library.

The information is also exposed to the standard command line output via the `-e` or `--show-codec` flag

See issue #79