### PR TITLE
Power options cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ For older versions (python 2.7, <3.4), you can continue using gpustat v0.x.
 [gh-issue-66]: https://github.com/wookayin/gpustat/issues/66
 
 
+Tests
+-----
+
+To run the test suite, execute `PYTEST_ADDOPTS="-s" python setup.py test`
+
+
 Changelog
 ---------
 

--- a/gpustat/cli.py
+++ b/gpustat/cli.py
@@ -96,12 +96,12 @@ def main(*argv):
     parser.add_argument(
         '-e', '--show-codec', nargs='?', const='enc,dec', default='',
         choices=['', 'enc', 'dec', 'enc,dec'],
-        help='Show encoder/decoder utilization'
+        help='Show encoder and/or decoder utilization'
     )
     parser.add_argument(
-        '-P', '--show-power', nargs='?', const='draw,limit',
-        choices=['', 'draw', 'limit', 'draw,limit', 'limit,draw'],
-        help='Show GPU power usage or draw (and/or limit)'
+        '-P', '--show-power', nargs='?', const='draw,limit', default='',
+        choices=['', 'draw', 'limit', 'draw,limit'],
+        help='Show GPU power usage or draw (and limit)'
     )
     parser.add_argument('--json', action='store_true', default=False,
                         help='Print all the information in JSON format')

--- a/gpustat/core.py
+++ b/gpustat/core.py
@@ -183,7 +183,7 @@ class GPUStat(object):
                  show_pid=False,
                  show_fan_speed=None,
                  show_codec="",
-                 show_power=None,
+                 show_power="",
                  gpuname_width=16,
                  term=None,
                  ):
@@ -264,7 +264,7 @@ class GPUStat(object):
 
         if show_power:
             reps += ",  %(CPowU)s{entry[power.draw]:>3}%(C0)s "
-            if show_power is True or 'limit' in show_power:
+            if 'limit' in show_power:
                 reps += "/ %(CPowL)s{entry[enforced.power.limit]:>3}%(C0)s "
                 reps += "%(CPowL)sW%(C0)s"
             else:
@@ -539,7 +539,7 @@ class GPUStatCollection(object):
     def print_formatted(self, fp=sys.stdout, force_color=False, no_color=False,
                         show_cmd=False, show_full_cmd=False, show_user=False,
                         show_pid=False, show_fan_speed=None,
-                        show_codec="", show_power=None,
+                        show_codec="", show_power="",
                         gpuname_width=16, show_header=True,
                         eol_char=os.linesep,
                         ):

--- a/gpustat/test_gpustat.py
+++ b/gpustat/test_gpustat.py
@@ -231,7 +231,7 @@ class TestGPUStat(object):
         gpustats.print_formatted(
             fp=fp, no_color=False, show_user=True,
             show_cmd=True, show_full_cmd=True, show_pid=True,
-            show_fan_speed=True, show_codec="enc,dec", show_power=True,
+            show_fan_speed=True, show_codec="enc,dec", show_power="limit",
         )
 
         result = fp.getvalue()
@@ -332,7 +332,7 @@ class TestGPUStat(object):
         TEST_OPTS = []
         TEST_OPTS += ['-a', '-c', '-u', '-p', '-e', '-P', '-f']
         TEST_OPTS += [('-e', ''), ('-P', '')]
-        TEST_OPTS += [('-e', 'enc,dec'), '-Plimit,draw']
+        TEST_OPTS += [('-e', 'enc,dec'), '-Pdraw,limit']
         TEST_OPTS += ['-cup', '-cpu', '-cufP']  # 'cpuePf'
 
         for opt in TEST_OPTS:


### PR DESCRIPTION
I ran through some inconsistencies when preparing my PR a couple weeks ago, thought I'd upstream them.

Basically, when run via the tests, show_power has types (`bool` or `NoneType` or `str`) that differ from when it's running through other means (`str`, set via the "choices" list).
I noticed this when creating the '-e` parameter, and the type consistency was a source of confusion. I speculate that the original cause is simply a bad copy/paste from other parameters that actually are booleans.

This PR also removes the `limit,draw` option, as it's exactly equivalent to `draw,limit`. One may think it behaves differently (switches the order or something). Best to have a canonical option instead, imo.
Technically, `draw,limit` is also exactly equivalent to `limit`, so if it were up to me, I would opt to remove one of them as well.