### PR TITLE
Do not list the same GPU process more than once

### DIFF
--- a/gpustat/core.py
+++ b/gpustat/core.py
@@ -463,6 +463,8 @@ class GPUStatCollection(object):
                 processes = []
                 nv_comp_processes = nv_comp_processes or []
                 nv_graphics_processes = nv_graphics_processes or []
+                # A single process might run in both of graphics and compute mode,
+                # However we will display the process only once
                 seen_pids = set()
                 for nv_process in nv_comp_processes + nv_graphics_processes:
                     if nv_process.pid in seen_pids:

--- a/gpustat/core.py
+++ b/gpustat/core.py
@@ -376,6 +376,8 @@ class GPUStatCollection(object):
                     GPUStatCollection.global_processes[nv_process.pid] = \
                         psutil.Process(pid=nv_process.pid)
                 ps_process = GPUStatCollection.global_processes[nv_process.pid]
+
+                # TODO: ps_process is being cached, but the dict below is not.
                 process['username'] = ps_process.username()
                 # cmdline returns full path;
                 # as in `ps -o comm`, get short cmdnames.
@@ -461,7 +463,11 @@ class GPUStatCollection(object):
                 processes = []
                 nv_comp_processes = nv_comp_processes or []
                 nv_graphics_processes = nv_graphics_processes or []
+                seen_pids = set()
                 for nv_process in nv_comp_processes + nv_graphics_processes:
+                    if nv_process.pid in seen_pids:
+                        continue
+                    seen_pids.add(nv_process.pid)
                     try:
                         process = get_process_info(nv_process)
                         processes.append(process)

--- a/gpustat/test_gpustat.py
+++ b/gpustat/test_gpustat.py
@@ -129,7 +129,7 @@ def _configure_mock(N=pynvml, scenario_nonexistent_pid=False):
 
         when(N).nvmlDeviceGetGraphicsRunningProcesses(handle)\
             .thenAnswer(_return_or_raise({
-                0: [],
+                0: [mock_process_t(48448, 4000*MB)],
                 1: [],
                 2: N.NVMLError_NotSupported(),
             }[i]))


### PR DESCRIPTION
A single process might appear in both of graphics and compute running
processes list (#18). In such cases, the same process (same PID)
would appear appearing twice. We fix this bug: list a process only once.