### PR TITLE
docs: fix simple typo, colorlize -> colorize

### DIFF
--- a/gpustat/util.py
+++ b/gpustat/util.py
@@ -21,7 +21,7 @@ def bytes2human(in_bytes):
 
 def prettify_commandline(cmdline, color_command='', color_text=''):
     '''
-    Prettify and colorlize a full command-line (given as list of strings),
+    Prettify and colorize a full command-line (given as list of strings),
     where command (basename) is highlighted in a different color.
     '''
     # cmdline: Iterable[str]


### PR DESCRIPTION
There is a small typo in gpustat/util.py.

Should read `colorize` rather than `colorlize`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md