### PR TITLE
Fix the afterimage texts that appear when the number of processes changes

### DIFF
--- a/gpustat/core.py
+++ b/gpustat/core.py
@@ -181,6 +181,7 @@ class GPUStat(object):
                  show_codec="",
                  show_power=None,
                  gpuname_width=None,
+                 eol_char=os.linesep,
                  term=None,
                  ):
         if term is None:
@@ -324,7 +325,7 @@ class GPUStat(object):
             for p in processes:
                 reps += ' ' + process_repr(p)
                 if show_full_cmd:
-                    full_processes.append(os.linesep + full_process_info(p))
+                    full_processes.append(eol_char + full_process_info(p))
         if show_full_cmd and full_processes:
             full_processes[-1] = full_processes[-1].replace('├', '└', 1)
             reps += ''.join(full_processes)
@@ -635,6 +636,7 @@ class GPUStatCollection(object):
                        show_codec=show_codec,
                        show_power=show_power,
                        gpuname_width=gpuname_width,
+                       eol_char=eol_char,
                        term=t_color)
             fp.write(eol_char)
 


### PR DESCRIPTION
When a new process is created or an old process is gone, command `python3 -m gpustat -i 5 --show-all --show-full-cmd` does not remove the old texts on the terminal.

![Screenshot 1](https://user-images.githubusercontent.com/16078332/120812621-bbf75880-c57f-11eb-8b61-8067d5f7c042.png)
![Screenshot 2](https://user-images.githubusercontent.com/16078332/120812166-51deb380-c57f-11eb-9e8e-665169367559.png)
