### PR TITLE
Use NVIDIA's official pynvml binding

### DIFF
--- a/gpustat/__init__.py
+++ b/gpustat/__init__.py
@@ -2,7 +2,7 @@
 The gpustat module.
 """
 
-__version__ = '1.0.0.dev1'
+__version__ = '1.0.0.dev2'
 
 from .core import GPUStat, GPUStatCollection
 from .core import new_query

--- a/gpustat/core.py
+++ b/gpustat/core.py
@@ -23,9 +23,9 @@ from datetime import datetime
 
 from six.moves import cStringIO as StringIO
 import psutil
-import pynvml as N
 from blessed import Terminal
 
+from gpustat.nvml import pynvml as N
 import gpustat.util as util
 
 

--- a/gpustat/nvml.py
+++ b/gpustat/nvml.py
@@ -2,21 +2,35 @@
 
 import textwrap
 
+
 try:
+    # Check pynvml version: we require 11.450.129 or newer.
+    # https://github.com/wookayin/gpustat/pull/107
     import pynvml
-    if not hasattr(pynvml, 'NVML_BRAND_TITAN_RTX'):
+    if not (
+        # Requires nvidia-ml-py >= 11.460.79
+        hasattr(pynvml, 'NVML_BRAND_NVIDIA_RTX') or
+        # Requires nvidia-ml-py >= 11.450.129, < 11.510.69
+        hasattr(pynvml, 'nvmlDeviceGetComputeRunningProcesses_v2')
+    ):
         raise RuntimeError("pynvml library is outdated.")
 except (ImportError, SyntaxError, RuntimeError) as e:
     raise ImportError(textwrap.dedent(
         """\
         pynvml is missing or an outdated version is installed.
 
-        Please reinstall `gpustat`:
-        $ pip install -I gpustat
+        We require nvidia-ml-py>=11.450.129; see GH-107 for more details.
 
-        or manually fix the package:
+        -----------------------------------------------------------
+        Please reinstall `gpustat`:
+
+        $ pip install --force-reinstall gpustat
+
+        if it still does not fix the problem, manually fix nvidia-ml-py
+        installation:
+
         $ pip uninstall nvidia-ml-py3
-        $ pip install -I 'nvidia-ml-py!=375.*'
+        $ pip install --force-reinstall 'nvidia-ml-py<=11.495.46'
         """)) from e
 
 

--- a/gpustat/nvml.py
+++ b/gpustat/nvml.py
@@ -1,0 +1,23 @@
+"""Imports pynvml with sanity checks and custom patches."""
+
+import textwrap
+
+try:
+    import pynvml
+    if not hasattr(pynvml, 'NVML_BRAND_TITAN_RTX'):
+        raise RuntimeError("pynvml library is outdated.")
+except (ImportError, SyntaxError, RuntimeError) as e:
+    raise ImportError(textwrap.dedent(
+        """\
+        pynvml is missing or an outdated version is installed.
+
+        Please reinstall `gpustat`:
+        $ pip install -I gpustat
+
+        or manually fix the package:
+        $ pip uninstall nvidia-ml-py3
+        $ pip install -I 'nvidia-ml-py!=375.*'
+        """)) from e
+
+
+__all__ = ['pynvml']

--- a/gpustat/test_gpustat.py
+++ b/gpustat/test_gpustat.py
@@ -13,12 +13,11 @@ from collections import namedtuple
 from io import StringIO    # Python 3 only
 
 import psutil
-import pynvml
-
 import pytest
 from mockito import when, mock, unstub
 
 import gpustat
+from gpustat.nvml import pynvml
 
 
 MB = 1024 * 1024

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ class DeployCommand(Command):
 
 install_requires = [
     'six>=1.7',
-    'nvidia-ml-py3>=7.352.0',
+    'nvidia-ml-py!=375.*',  # see https://forums.developer.nvidia.com/t/mistake-with-nvidia-ml-py-on-pypi/112942
     'psutil>=5.6.0',    # GH-1447
     'blessed>=1.17.1',  # GH-126
 ]

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ class DeployCommand(Command):
 
 install_requires = [
     'six>=1.7',
-    'nvidia-ml-py!=375.*',  # see https://forums.developer.nvidia.com/t/mistake-with-nvidia-ml-py-on-pypi/112942
+    'nvidia-ml-py>=11.450.129,<=11.495.46',  # see #107
     'psutil>=5.6.0',    # GH-1447
     'blessed>=1.17.1',  # GH-126
 ]


### PR DESCRIPTION
Since 2021, NVIDIA provides an official python binding `pynvml`: https://pypi.org/project/nvidia-ml-py/#history
which should replace a third-party community fork [nvidia-ml-py3](https://github.com/nicolargo/nvidia-ml-py3) that we have been using.

The main motivations are (1) to use an official library and (2) to add MIG support.
See #102 for more details.

Need to test whether:

- The new pynvml API works well on **old & recent** NVIDIA Drivers; maybe some monkey patching needed 
  (see https://github.com/wookayin/gpustat/issues/102#issuecomment-892833816)
- The new pynvml API works well on Windows
  (see #90)

/cc @XuehaiPan @Stonesjtu 