### PR TITLE
WINDOWS: psutil can fail to get process info

### DIFF
--- a/gpustat/core.py
+++ b/gpustat/core.py
@@ -488,6 +488,8 @@ class GPUStatCollection(object):
                         # TODO: add some reminder for NVML broken context
                         # e.g. nvidia-smi reset  or  reboot the system
                         pass
+                    except psutil.AccessDenied:
+                        pass
                     except FileNotFoundError:
                         # Ignore the exception which probably has occured
                         # from psutil, due to a non-existent PID (see #95).

--- a/gpustat/test_gpustat.py
+++ b/gpustat/test_gpustat.py
@@ -165,6 +165,7 @@ def _configure_mock(N=pynvml, scenario_nonexistent_pid=False,
         p.cmdline = lambda: [cmdline]
         p.cpu_percent = lambda: cpuutil
         p.memory_percent = lambda: memutil
+        p.pid = pid
         return p
 
     when(psutil).Process(...)\


### PR DESCRIPTION
Preallocate a default process dict with the valid PID, and return it when `get_process_info` errors. Also catch `psutil.AccessDenied` on windows where sometimes the user cannot query all processes.

