### PR TITLE
Add pynvml compatibility by monkey-patching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: "Run Tests"
 on: [push, pull_request, workflow_dispatch]
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   unit-tests:
     name: "Unit Tests"
@@ -22,6 +26,9 @@ jobs:
             python-version: "3.10"
           - os: ubuntu-latest
             python-version: "3.11"
+          - os: ubuntu-latest
+            python-version: "3.11"
+            pynvml-version: 11.495.46
           - os: windows-latest
             python-version: "3.8"
           - os: windows-latest
@@ -46,6 +53,9 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -e ".[test]"
+          if [ -n "${{ matrix.pynvml-version }}" ]; then
+            pip install nvidia-ml-py==${{ matrix.pynvml-version }}
+          fi
           python -m gpustat --version
 
       - name: Run tests

--- a/gpustat/core.py
+++ b/gpustat/core.py
@@ -459,7 +459,9 @@ class GPUStatCollection(object):
                 fan_speed = None  # Not supported
 
             try:
-                memory = N.nvmlDeviceGetMemoryInfo(handle)  # in Bytes
+                # memory: in Bytes
+                # Note that this is a compat-patched API (see gpustat.nvml)
+                memory = N.nvmlDeviceGetMemoryInfo(handle)
             except N.NVMLError as e:
                 log.add_exception("memory", e)
                 memory = None  # Not supported
@@ -479,7 +481,7 @@ class GPUStatCollection(object):
             try:
                 utilization_dec = N.nvmlDeviceGetDecoderUtilization(handle)
             except N.NVMLError as e:
-                log.add_exception("utilization_dnc", e)
+                log.add_exception("utilization_dec", e)
                 utilization_dec = None  # Not supported
 
             try:

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ class DeployCommand(Command):
 
 
 install_requires = [
-    'nvidia-ml-py>=11.450.129,<=11.495.46',  # see #107
+    'nvidia-ml-py>=11.450.129',  # see #107, #143
     'psutil>=5.6.0',    # GH-1447
     'blessed>=1.17.1',  # GH-126
 ]


### PR DESCRIPTION
The purpose of this PR is to relax the strict pynvml requirement (`<= 11.495.46`) introduced in #107.


pynvml 11.510.69 has broken the backward compatibility by removing `nvml.nvmlDeviceGetComputeRunningProcesses_v2` which is replaced by v3 APIs (`nvml.nvmlDeviceGetComputeRunningProcesses_v3`), but this function does not exist for old nvidia drivers less than 510.39.01.

Therefore we pinned pynvml version at 11.495.46 in gpustat v1.0 (#107), but we actually have to use recent pynvml versions for "latest" or modern NVIDIA drivers. To make compute/graphics process information work correctly when a combination of old nvidia drivers (`< 510.39`) AND `pynvml >= 11.510.69` is used, we need to monkey-patch pynvml functions in our custom manner such that, for instance, when v3 API is introduced, we can simply fallback to v2 APIs to retrieve the process information.
