### PR TITLE
Config

### DIFF
--- a/gpustat/cli.py
+++ b/gpustat/cli.py
@@ -6,6 +6,7 @@ from contextlib import suppress
 from blessed import Terminal
 
 from gpustat import __version__
+from gpustat.config import PrintConfig
 from gpustat.core import GPUStatCollection
 
 
@@ -52,7 +53,7 @@ def get_complete_for_one_or_zero(input):
     return output
 
 
-def print_gpustat(*, id=None, json=False, debug=False, **kwargs):
+def print_gpustat(*, id=None, json=False, debug=False, config=None, **kwargs):
     '''Display the GPU query results into standard output.'''
     try:
         gpu_stats = GPUStatCollection.new_query(debug=debug, id=id)
@@ -76,7 +77,9 @@ def print_gpustat(*, id=None, json=False, debug=False, **kwargs):
         sys.stderr.flush()
         sys.exit(1)
 
-    if json:
+    if config is not None:
+        gpu_stats.print_from_config(config, sys.stdout)
+    elif json:
         gpu_stats.print_json(sys.stdout)
     else:
         gpu_stats.print_formatted(sys.stdout, **kwargs)
@@ -189,7 +192,12 @@ def main(*argv):
     )
     parser.add_argument('-v', '--version', action='version',
                         version=('gpustat %s' % __version__))
+    parser.add_argument('--config', default=None, const=True, nargs="?")
     args = parser.parse_args(argv[1:])
+
+
+    if args.config is not None:
+        args.config = PrintConfig()
     # TypeError: GPUStatCollection.print_formatted() got an unexpected keyword argument 'print_completion'
     with suppress(AttributeError):
         del args.print_completion  # type: ignore

--- a/gpustat/config.py
+++ b/gpustat/config.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field, fields
 from typing import Dict, Literal, Optional, TypeVar, Union
 
 from blessed import Terminal
-from omegaconf import OmegaConf
+# from omegaconf import OmegaConf
 
 
 @dataclass
@@ -153,5 +153,5 @@ class PrintConfig:
         cp.font_modifiers.to_term(terminal)
         return cp
 
-    def to_yaml(self) -> str:
-        return OmegaConf.to_yaml(self)
+    # def to_yaml(self) -> str:
+    #     return OmegaConf.to_yaml(self)

--- a/gpustat/config.py
+++ b/gpustat/config.py
@@ -1,0 +1,157 @@
+"""
+Defines a dataclass `PrintConfig` to handle options for printing gpustat to the
+terminal, such as colors, other modifiers and overall arangement
+"""
+
+import re
+from copy import deepcopy
+from dataclasses import dataclass, field, fields
+from typing import Dict, Literal, Optional, TypeVar, Union
+
+from blessed import Terminal
+from omegaconf import OmegaConf
+
+
+@dataclass
+class ConditionalFormat:
+    # TODO: Allow refernce to something else?
+    mode: Literal["Larger", "Smaller", "Equal"]
+    val: Union[int, float, str]
+    eval_true: str
+    eval_false: str
+    eval_error: str = "normal"
+
+StrPlus = TypeVar("StrPlus", str, ConditionalFormat)
+
+def str_to_term(s: StrPlus, terminal: Terminal) -> StrPlus:
+    """Converts a color entry below from human readable form to a ANSI-escape
+    code of the specific terminal"""
+    if isinstance(s, ConditionalFormat):
+        s.eval_true = str_to_term(s.eval_true, terminal)
+        s.eval_false = str_to_term(s.eval_false, terminal)
+        s.eval_error = str_to_term(s.eval_error, terminal)
+        return s
+
+    code = terminal.normal # reset previous color/style
+    for part in s.split(";"):
+        if hasattr(terminal, part):
+            code += getattr(terminal, part)
+        else:
+            try:
+                # TODO: background modifier ?
+                r, g, b = map(int, part.split(","))
+                code += terminal.color_rgb(r, g, b)
+            except:
+                raise ValueError(f"Unknown color/style modifier: {part}")
+    return code
+
+@dataclass
+class ProcecessFontModifiers:
+    """Set colors for each kind of metric of a process running on a gpu"""
+    username: str = "bold;black" # change here for readable dark terminals
+    command: str = "blue"
+    # TODO: full_command colors command uses two colors
+    full_command: str = "cyan"
+    gpu_memory_usage: str = "yellow"
+    cpu_percent: str = "green"
+    cpu_memory_usage: str = "yellow"
+    pid: str = "normal"
+
+    def to_term(self, terminal: Terminal):
+        for var in fields(self):
+            value = getattr(self, var.name)
+            if not isinstance(value, (str, ConditionalFormat)):
+                continue
+            modifier = str_to_term(value, terminal)
+            setattr(self, var.name, modifier)
+
+
+@dataclass
+class GPUFontModifiers:
+    """Set colors for each kind of metric of a gpu"""
+    # NOTE: dots in json are replaced with underscores here
+    index: str = "cyan"
+    uuid: str = "normal" # Not a default option
+    name: str = "blue"
+    temperature_gpu: str = "red" # TODO: is Conditional
+    fan_speed: str = "cyan" # TODO: is Conditional
+    utilization_gpu: str = "green" # TODO: is Conditional
+    utilization_enc: str = "green" # TODO: is Conditional
+    utilization_dec: str = "green" # TODO: is Conditional
+    power_draw: str = "magenta" # TODO: is Conditional
+    enforced_power_limit: str = "magenta"
+    memory_used: str = "yellow"
+    memory_total: str = "yellow"
+    processes_font_modifiers: ProcecessFontModifiers = ProcecessFontModifiers()
+
+    def to_term(self, terminal: Terminal):
+        self.processes_font_modifiers.to_term(terminal)
+        for var in fields(self):
+            value = getattr(self, var.name)
+            if not isinstance(value, (str, ConditionalFormat)):
+                continue
+            modifier = str_to_term(value, terminal)
+            setattr(self, var.name, modifier)
+
+@dataclass
+class FontModifiers:
+    """Set colors for each kind of all metric indepentendly"""
+    # NOTE: Should this be overwritable in the string? Seems useless tbh
+    gpu_font_modifiers: GPUFontModifiers = GPUFontModifiers()
+    hostname: str = "bold;gray"
+    driver_version: str = "bold;black"
+    query_time: str = "normal"
+
+    def to_term(self, terminal: Terminal):
+        self.gpu_font_modifiers.to_term(terminal)
+        for var in fields(self):
+            value = getattr(self, var.name)
+            if not isinstance(value, (str, ConditionalFormat)):
+                continue
+            modifier = str_to_term(value, terminal)
+            setattr(self, var.name, modifier)
+
+@dataclass
+class PrintConfig:
+    font_modifiers: FontModifiers = FontModifiers()
+    # NOTE: Introduce color reset shortcut?
+
+    # # Config 1: Roughly default `gpustat`
+    # header: Optional[str] = "$hostname:{width}$ $query_time$ $driver_version$\n{gpus}"
+    # gpus: Optional[str] = "[$index$] $name:{width}$ | $temperature_gpu:2${t.red}°C{t.normal}, $utilization_gpu:3$ {t.green}%{t.normal} | $memory_used:5$ / $memory_total:5$ MB | {processes}"
+    # process: Optional[str] = "$username$ ($gpu_memory_usage$ MB)"
+    # gpu_sep: str = "\n"
+    # processes_sep: str = ", "
+
+    # Config 2: Boxed config
+    header: Optional[str] = (
+        "┌{empty:─>{width}}{empty:─>39}┐\n"
+        "│ $hostname:{width}$ $query_time$ $driver_version:>11$ │\n"
+        "{gpus}\n"
+        "└{empty:─>{width}}{empty:─>39}┘"
+    )
+    gpus: Optional[str] = "│ [$index$] $name:{width}$ │ $temperature_gpu:2${t.red}°C{t.normal}, $utilization_gpu:3$ {t.green}%{t.normal} │ $memory_used:5$ / $memory_total:5$ MB │{processes}"
+    process: Optional[str] = "\n│     $username:>{width}$ │ $gpu_memory_usage$ MB {empty: >22}│"
+    gpu_sep: str = "\n"
+    processes_sep: str = ""
+
+    gpuname_width: Optional[int] = None
+    use_color: Optional[bool] = None
+    extra_colors: Dict[str, str] = field(default_factory=dict) # dict()
+
+    def __post_init__(self):
+        def inner_prepare(s):
+            return re.sub(r"\$([^:$]*?)(:[^:$]*?)?\$", r"{mods.\1}{\1\2}{t.normal}", s)
+        self.header = inner_prepare(self.header)
+        self.gpus = inner_prepare(self.gpus)
+        self.process = inner_prepare(self.process)
+
+    def to_term(self, terminal: Terminal):
+        cp = deepcopy(self)
+        for key, color in cp.extra_colors.values():
+            cp.extra_colors[key] = str_to_term(color, terminal)
+        cp.font_modifiers.to_term(terminal)
+        return cp
+
+    def to_yaml(self) -> str:
+        return OmegaConf.to_yaml(self)

--- a/gpustat/core.py
+++ b/gpustat/core.py
@@ -7,7 +7,7 @@ Implementation of gpustat
 @url https://github.com/wookayin/gpustat
 """
 
-from typing import Any, Dict, Sequence, TypeVar
+from typing import Sequence, TypeVar
 import json
 import locale
 import os.path
@@ -19,12 +19,10 @@ from io import StringIO
 
 import psutil
 from blessed import Terminal
-from gpustat.config import PrintConfig
 
 import gpustat.util as util
+from gpustat.config import PrintConfig
 from gpustat.nvml import pynvml as N
-
-from pprint import pprint
 
 
 NOT_SUPPORTED = 'Not Supported'
@@ -783,7 +781,7 @@ class GPUStatCollection(Sequence[GPUStat]):
 
         # Gathering the info
         vars = self.jsonify()
-        vars: dict = recursive_replace(vars)
+        vars = recursive_replace(vars)
         if IS_WINDOWS:
             # no localization is available; just use a reasonable default
             # same as str(timestr) but without ms


### PR DESCRIPTION
Hello @wookayin !

First of all, thank you so much for this package.

I have implemented a a new function to format the output of gpustat using a python dataclass. The class saves a color for each entry provided by gpustat, names are the same as in the json (except for replacing `.` with `_`), as well as having a template to layout the final string. This should address issues #51 and #9. Here are two example outputs using it:

![gpustat_box_screen](https://user-images.githubusercontent.com/22528125/230606635-757fc818-46a0-4b00-a957-50ee837dfa30.jpg)
![gpustat_default_screen](https://user-images.githubusercontent.com/22528125/230606622-234fbd48-a4f7-4031-9aa5-27efdb547b9c.jpg)

The output is determined by three strings that are formatted using `str.format`, one for the header, the gpu info and the process info. In that environment the corresponding information is provided, and can be used using the standard `{name:specifier}`. I have added an additional parsing for `... $name:specifier$ ...` to input the correct color before and switch back to normal formatting afterward. Also as in your code there are some extra things added like the gpu-name width, the blessed terminal interface and an empty string (to repeat a character `width` times).

There are some open todos that need to be implemented before this should be pushed, but I wanted to ask for your opinion so far before I continue this.

Remaining todos:
- Connection configuration file <-> dataclass. This should be really easy to do when using one of the many libraries designed to do exactly that. I would suggest [omgeconf](https://github.com/omry/omegaconf) if you are fine with adding this as another dependency.
- Currently it's either using the config or command line options. Reading and adding command line options with OmegaConf is no problem. The real issue here is that the config at the moment requires a preconfigured template, so that needs to be dynamically adjustable if no fixed template is specified. Probably the biggest todo.
- Colors are static at the moment, but I noticed when writing my code that you highlight certain things based on ratios. I'm not sure how customizable this functionality should be. I was thinking of implementing something like "{field a} {operator} {field b) {comp} {field c}", e.g "power_usage / power_limit > 0.9" or "username == jenuk" as a test? I feel like this would support enough flexibility.
- Maybe adding an option to color preceding/following characters in the same color as the metrics.
- Updating the readme to explain all changes.

Do you have any additional feedback/wishes for this? If you are happy with this, I will finish it.

