### PR TITLE
Setup default stdout to utf-8

### DIFF
--- a/gpustat/core.py
+++ b/gpustat/core.py
@@ -32,7 +32,9 @@ from blessed import Terminal
 
 import gpustat.util as util
 from gpustat.nvml import pynvml as N
+import codecs
 
+sys.stdout = codecs.getwriter("utf-8")(sys.stdout.detach()) #Setup the default stdout to utf-8
 NOT_SUPPORTED = 'Not Supported'
 MB = 1024 * 1024
 


### PR DESCRIPTION
Error occurred when Linux Language environment variables  is set to "zh_CN.UTF-8": 
File "/usr/local/lib/python3.6/dist-packages/gpustat/core.py", line 397, in print_to
    fp.write(''.join(reps))
UnicodeEncodeError: 'ascii' codec can't encode character '\xb0' in position 61: ordinal not in range(128)

steps to recurrent:
1. set the LANG in Linux command line:
```
export LANG='zh_US.UTF-8'
```
2. run `gpustat`
3. restult:
```
Traceback (most recent call last):
  File "/usr/local/bin/gpustat", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.6/dist-packages/gpustat/cli.py", line 217, in main
    print_gpustat(**vars(args))
  File "/usr/local/lib/python3.6/dist-packages/gpustat/cli.py", line 82, in print_gpustat
    gpu_stats.print_formatted(sys.stdout, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/gpustat/core.py", line 716, in print_formatted
    term=t_color)
  File "/usr/local/lib/python3.6/dist-packages/gpustat/core.py", line 397, in print_to
    fp.write(''.join(reps))
UnicodeEncodeError: 'ascii' codec can't encode character '\xb0' in position 61: ordinal not in range(128)
```

Runtime environment:
Linux 18.04 Kernel 4.15.0-212-generic
Python 3.6.9

Solution:
**Setup default stdout to utf-8** as commit