### PR TITLE
perf: Improve performance by reducing redundant pynvml.nvmlInit call

### DIFF
--- a/gpustat/core.py
+++ b/gpustat/core.py
@@ -31,6 +31,7 @@ import psutil
 from blessed import Terminal
 
 import gpustat.util as util
+import gpustat.nvml as nvml
 from gpustat.nvml import pynvml as N
 from gpustat.nvml import check_driver_nvml_version
 
@@ -443,7 +444,7 @@ class GPUStatCollection(Sequence[GPUStat]):
     def new_query(debug=False, id=None) -> 'GPUStatCollection':
         """Query the information of all the GPUs on local machine"""
 
-        N.nvmlInit()
+        nvml.ensure_initialized()
         log = util.DebugHelper()
 
         def _decode(b: Union[str, bytes]) -> str:
@@ -625,7 +626,6 @@ class GPUStatCollection(Sequence[GPUStat]):
         if debug:
             log.report_summary()
 
-        N.nvmlShutdown()
         return GPUStatCollection(gpu_list, driver_version=driver_version)
 
     def __len__(self):
@@ -752,15 +752,10 @@ def new_query() -> GPUStatCollection:
 def gpu_count() -> int:
     '''Return the number of available GPUs in the system.'''
     try:
-        N.nvmlInit()
+        nvml.ensure_initialized()
         return N.nvmlDeviceGetCount()
     except N.NVMLError:
         return 0  # fallback
-    finally:
-        try:
-            N.nvmlShutdown()
-        except N.NVMLError:
-            pass
 
 
 def is_available() -> bool:

--- a/gpustat/test_gpustat.py
+++ b/gpustat/test_gpustat.py
@@ -48,6 +48,7 @@ def _configure_mock(N=pynvml,
     unstub(N)  # reset all the stubs
 
     when(N).nvmlInit().thenReturn()
+    gpustat.nvml._initialized = True  # nvmlInit() is called upon module import
     when(N).nvmlShutdown().thenReturn()
     when(N).nvmlSystemGetDriverVersion().thenReturn('415.27.mock')
 


### PR DESCRIPTION
### perf: Call nvmlInit() and nvmlShutdown() only once (fixes #54)

Lots of time is spent on nvmlInit() and nvmlShutdown() for each
new_query call. When running in a loop mode (-i), we do not need to
initialize and shutdown the nvml library because nvml APIs will be used
throughout the lifespan of the gpustat process.

Upon importing `gpustat.pynvml`, nvmlInit() will always be called.
